### PR TITLE
Implement page pooling + checkout/checkin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ make best use of your resources.
 
 > Add Chromesmith to your application supervision tree.
 
-```
+Use `Chromesmith.child_spec/2` to create the child specification to be put in your application's supervisor.
+
+See [here](#) for configuration options.
+
+```elixir
 defmodule MyApp.Application do
   @moduledoc false
 

--- a/lib/chromesmith.ex
+++ b/lib/chromesmith.ex
@@ -7,24 +7,24 @@ defmodule Chromesmith do
   defstruct [
     supervisor: nil, # Chromesmith.Supervisor PID
     process_pool_size: 0, # How many Headless Chrome instances to spawn
-    number_of_pages_per_process: 0, # How many Pages per Instance
-    workers: [], # List of worker tuples, {pid, number_of_used_pages, number_of_total_pages}
-    chrome_options: [] # Options to pass into `:chrome_launcher`
+    page_pool_size: 0, # How many Pages per Instance
+    process_pools: [], # List of process pool tuples, {pid, available_pids, all_pids}
+    chrome_options: [], # Options to pass into `:chrome_launcher`
   ]
 
   @type t :: %__MODULE__{
     supervisor: pid(),
     process_pool_size: non_neg_integer(),
-    number_of_pages_per_process: non_neg_integer(),
-    workers: [{pid(), non_neg_integer(), non_neg_integer()}]
+    page_pool_size: non_neg_integer(),
+    process_pools: [{pid(), [pid()], [pid()]}],
+    chrome_options: []
   }
 
   @doc """
   Check out a Page from one of the headless chrome processes.
   """
-  def checkout(pid, should_block \\ true)
-  def checkout(pid, should_block) do
-    GenServer.call(pid, {:checkout, should_block})
+  def checkout(pid) do
+    GenServer.call(pid, :checkout)
   end
 
   @doc """
@@ -38,11 +38,10 @@ defmodule Chromesmith do
   # Private
   # ---
 
-  def child_spec(name, opts, start_opts \\ [])
-  def child_spec(name, opts, start_opts) do
+  def child_spec(name, opts) do
     %{
       id: name,
-      start: {__MODULE__, :start_link, [opts, start_opts]},
+      start: {__MODULE__, :start_link, [opts, [name: name]]},
       type: :worker
     }
   end
@@ -57,7 +56,7 @@ defmodule Chromesmith do
     state = %Chromesmith{
       supervisor: supervisor_pid,
       process_pool_size: Keyword.get(opts, :process_pool_size, 4),
-      number_of_pages_per_process: Keyword.get(opts, :number_of_pages_per_process, 16),
+      page_pool_size: Keyword.get(opts, :page_pool_size, 16),
       chrome_options: Keyword.get(opts, :chrome_options, [])
     }
 
@@ -65,8 +64,8 @@ defmodule Chromesmith do
   end
 
   def init(%Chromesmith{} = state) do
-    workers = prepopulate_pool(state.supervisor, state)
-    {:ok, %{state | workers: workers}}
+    process_pools = prepopulate_pool(state.supervisor, state)
+    {:ok, %{state | process_pools: process_pools}}
   end
 
   def prepopulate_pool(supervisor, state) do
@@ -83,13 +82,61 @@ defmodule Chromesmith do
       supervisor,
       %{
         id: index,
-        start: {Chromesmith.Worker, :start_link, [{index, state.chrome_options}]},
+        start: {Chromesmith.Worker, :start_link, [
+          {index, state.chrome_options}
+        ]},
         restart: :temporary,
         shutdown: 5000,
         type: :worker
       }
     )
 
-    {child, 0, state.number_of_pages_per_process}
+    page_pids =
+      child
+      |> Chromesmith.Worker.start_pages([page_pool_size: state.page_pool_size])
+
+    {child, page_pids, page_pids}
+  end
+
+  # ---
+  # GenServer Handlers
+  # ----
+
+  def handle_call(:checkout, _from, state) do
+    {updated_pools, page} =
+      state.process_pools
+      |> Enum.reduce({[], nil}, fn({pid, available_pages, total_pages} = pool, {pools, found_page}) ->
+        if is_nil(found_page) and length(available_pages) > 0 do
+          [checked_out_page | new_pages] = available_pages
+          new_pool = {pid, new_pages, total_pages}
+          {[new_pool | pools], checked_out_page}
+        else
+          {[pool | pools], found_page}
+        end
+      end)
+
+    if page do
+      {:reply, {:ok, page}, %{state | process_pools: updated_pools}}
+    else
+      {:reply, :error, state}
+    end
+  end
+
+  def handle_cast({:checkin, page}, state) do
+    updated_pools =
+      state.process_pools
+      |> Enum.map(fn({pid, available_pages, total_pages} = pool) ->
+        # If this page is from this pool, (part of total pages)
+        # then return it as an available page only if it hasn't
+        # been added before (not already checked into available_pages
+
+        if Enum.find(total_pages, &(&1 == page)) && !Enum.find(available_pages, &(&1 == page)) do
+          {pid, [page | available_pages], total_pages}
+        else
+          pool
+        end
+      end)
+
+    {:noreply, %{state | process_pools: updated_pools}}
   end
 end

--- a/lib/chromesmith.ex
+++ b/lib/chromesmith.ex
@@ -1,6 +1,27 @@
 defmodule Chromesmith do
   @moduledoc """
   Main module for Chromesmith.
+
+  > Add Chromesmith to your application supervision tree:
+
+      defmodule ChromesmithExample.Application do
+        use Application
+
+        def start(_type, _args) do
+          children = [
+            Chromesmith.child_spec(:chrome_pool, [process_pool_size: 2, page_pool_size: 1])
+          ]
+
+          opts = [strategy: :one_for_one, name: ChromesmithExample.Supervisor]
+          Supervisor.start_link(children, opts)
+        end
+      end
+
+  Using `Chromesmith.child_spec/2`, you can provide multiple options to configure the pool:
+
+  * `:process_pool_size` - How many Chrome instances to open
+  * `:page_pool_size` - How many pages to open per chrome instance
+  * `:chrome_options` - Additional chrome headless CLI flags to pass on startup.
   """
   use GenServer
 

--- a/lib/chromesmith.ex
+++ b/lib/chromesmith.ex
@@ -64,11 +64,11 @@ defmodule Chromesmith do
   end
 
   def init(%Chromesmith{} = state) do
-    process_pools = prepopulate_pool(state.supervisor, state)
+    process_pools = spawn_pools(state.supervisor, state)
     {:ok, %{state | process_pools: process_pools}}
   end
 
-  def prepopulate_pool(supervisor, state) do
+  def spawn_pools(supervisor, state) do
     children =
       Enum.map(1..state.process_pool_size, fn(index) ->
         start_worker(supervisor, index, state)

--- a/lib/worker.ex
+++ b/lib/worker.ex
@@ -1,13 +1,38 @@
 defmodule Chromesmith.Worker do
   use GenServer
 
+  alias ChromeRemoteInterface.{Session, PageSession}
+
   def start_link({index, chrome_opts}) do
     GenServer.start_link(__MODULE__, {index, chrome_opts})
   end
 
   def init({index, _opts}) do
-    ChromeLauncher.launch([
+    opts = [
       remote_debugging_port: 9222 + index
+    ]
+
+    {:ok, pid} = ChromeLauncher.launch(opts)
+
+    {:ok, %{pid: pid, page_sessions: [], opts: opts}}
+  end
+
+  def start_pages(pid, opts) do
+    GenServer.call(pid, {:start_pages, opts})
+  end
+
+  def handle_call({:start_pages, opts}, _from, state) do
+    session = Session.new([
+      port: state.opts[:remote_debugging_port]
     ])
+
+    page_sessions =
+      Enum.map(1..opts[:page_pool_size] - 1, fn(_) ->
+        {:ok, page} = Session.new_page(session)
+        {:ok, page_session} = PageSession.start_link(page)
+        page_session
+      end)
+
+    {:reply, page_sessions, %{state | page_sessions: page_sessions}}
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], []},
-  "chrome_launcher": {:git, "https://github.com/andrewvy/chrome-launcher.git", "75b07be5a6054886c45065da62d94975b69f0467", []},
+  "chrome_launcher": {:git, "https://github.com/andrewvy/chrome-launcher.git", "ca41b01414ce5afdaad0a68b4e4aa76501ff83d8", []},
   "chrome_remote_interface": {:git, "https://github.com/andrewvy/chrome-remote-interface.git", "e67bc44f228c6bec92b4e9a56d13b730b7b27df0", []},
   "erlexec": {:hex, :erlexec, "1.7.1", "6ddbd40fa202084ed0bdaf95a50c334acaa5644ae213b903cd4094a78ae79734", [:rebar3], []},
   "hackney": {:hex, :hackney, "1.9.0", "51c506afc0a365868469dcfc79a9d0b94d896ec741cfd5bd338f49a5ec515bfe", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, optional: false]}, {:idna, "5.1.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},

--- a/test/chromesmith_test.exs
+++ b/test/chromesmith_test.exs
@@ -1,4 +1,22 @@
 defmodule ChromesmithTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
+
   doctest Chromesmith
+
+  setup_all do
+    {:ok, pid} = Chromesmith.start_link([process_pool_size: 1, page_pool_size: 1])
+    [pool_pid: pid]
+  end
+
+  test "Can checkout page", context do
+    {:ok, page_pid} = Chromesmith.checkout(context[:pool_pid])
+    assert :ok == Chromesmith.checkin(context[:pool_pid], page_pid)
+  end
+
+  test "Checking out more than enough pages will return a :none_available message", context do
+    {:ok, pid} = Chromesmith.checkout(context[:pool_pid])
+
+    assert {:error, :none_available} == Chromesmith.checkout(context[:pool_pid], false)
+    assert :ok == Chromesmith.checkin(context[:pool_pid], pid)
+  end
 end


### PR DESCRIPTION
This builds off of: https://github.com/andrewvy/chromesmith/issues/1

### Notes

This is a super early implementation that is in need of some refactoring soon. :) But this builds a simple system for checking in/out page pids for use with `:chrome_remote_interface`.

Right now, the simple algorithm is as follows:
- Loop through each pool (A `Chromesmith.Worker` that manages a chrome instance, which pools its own pages)
- Return a page from the first pool that has available pages.
- Else, if there are no pages to return, return an `:error`

In the future, we should order the pools from low to highest usage, (ex: we should pick a page from the pool with the highest amount of available pages first.)

TODOs:
- [x] `[page_pool_size: 1]` results in two pages per process. This is because Chrome boots up with a default page already. Need to handle this case.
- [x] Additional checkouts while there are no available pages should be allowed to block/queue up.
  - If there isn't any pages available, add the requestor process to a queue
  - On the next checkin of a page
    - Pop off the queue and give the checked-in worker the page.
    - If no queued calls, return page to available pages in respective pool.

---

### Usage Examples

> Using `Chromesmith.child_spec` to add to the supervisor tree.

```elixir
defmodule ChromesmithExample.Application do
  use Application

  def start(_type, _args) do
    children = [
      Chromesmith.child_spec(:chrome_pool, [process_pool_size: 2, page_pool_size: 1])
    ]

    opts = [strategy: :one_for_one, name: ChromesmithExample.Supervisor]
    Supervisor.start_link(children, opts)
  end
end
```

> Use `Chromesmith.checkout/1` to check out a page process.

```elixir
> {:ok, pid} = Chromesmith.checkout(:chrome_pool)
{:ok, #PID<0.281.0>}
```

> Use `Chromesmith.checkin/2` to check in the page process back into the pool of pools.

```elixir
> Chromesmith.checkin(:chrome_pool, pid)
:ok
```